### PR TITLE
Better larva progression.

### DIFF
--- a/code/datums/gamemodes/game_mode.dm
+++ b/code/datums/gamemodes/game_mode.dm
@@ -657,13 +657,13 @@ Sensors indicate [numXenosShip ? "[numXenosShip]" : "no"] unknown lifeform signa
 			to_chat(player, output)
 
 
-/datum/game_mode/proc/count_humans_and_xenos(list/z_levels = SSmapping.levels_by_any_trait(list(ZTRAIT_MARINE_MAIN_SHIP, ZTRAIT_GROUND, ZTRAIT_RESERVED)))
+/datum/game_mode/proc/count_humans_and_xenos(list/z_levels = SSmapping.levels_by_any_trait(list(ZTRAIT_MARINE_MAIN_SHIP, ZTRAIT_GROUND, ZTRAIT_RESERVED)), count_ssd = FALSE)
 	var/num_humans = 0
 	var/num_xenos = 0
 
 	for(var/i in GLOB.alive_human_list)
 		var/mob/living/carbon/human/H = i
-		if(!H.client)
+		if(!H.client && !count_ssd)
 			continue
 		if(H.status_flags & XENO_HOST)
 			continue
@@ -673,7 +673,7 @@ Sensors indicate [numXenosShip ? "[numXenosShip]" : "no"] unknown lifeform signa
 
 	for(var/i in GLOB.alive_xeno_list)
 		var/mob/living/carbon/xenomorph/X = i
-		if(!X.client)
+		if(!X.client && !count_ssd)
 			continue
 		if((!(X.z in z_levels) && !X.is_ventcrawling) || isspaceturf(X.loc))
 			continue


### PR DESCRIPTION
This could be improved for performance, but the logic is there.
* Removed the time limit. Xenos will keep respawning until the objectives are done or the resin silos are gone.
* The higher the marine-to-xeno ratio it is, the faster xenos regain larvas.
* Burrowed larvas and SSD xenos and marines now count for the ratio.
* If at any point there are more than 5 marines per xeno+burrowed, xenos will gain the larvas to fill the gap.
* Tweaked the respawn proc to be in line with the larva gains.